### PR TITLE
Fix npm update issue

### DIFF
--- a/Dockerfile.alpine-node
+++ b/Dockerfile.alpine-node
@@ -42,6 +42,7 @@ RUN info(){ printf '\n--\n%s\n--\n\n' "$*"; } \
     openssl libgcc libstdc++ \
  && rm -rf /var/cache/apk/* \
  && info "==> Updating NPM..." \
+ && npm config set unsafe-perm true \
  && npm i -g npm@$NPM_VERSION \
  && info "==> Cleaning up..." \
  && npm cache clean --force \


### PR DESCRIPTION
We get the following error when building npm and updating it on Alpine OS on Ubuntu host.

```Error: could not get uid/gid
[ 'nobody', 0 ]

    at /usr/lib/node_modules/npm/node_modules/uid-number/uid-number.js:37:16
    at ChildProcess.exithandler (child_process.js:282:5)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
TypeError: Cannot read property 'get' of undefined
    at errorHandler (/usr/lib/node_modules/npm/lib/utils/error-handler.js:205:18)
    at /usr/lib/node_modules/npm/bin/npm-cli.js:83:20
    at cb (/usr/lib/node_modules/npm/lib/npm.js:224:22)
    at /usr/lib/node_modules/npm/lib/npm.js:262:24
    at /usr/lib/node_modules/npm/lib/config/core.js:81:7
    at Array.forEach (<anonymous>)
    at /usr/lib/node_modules/npm/lib/config/core.js:80:13
    at f (/usr/lib/node_modules/npm/node_modules/once/once.js:25:25)
    at afterExtras (/usr/lib/node_modules/npm/lib/config/core.js:178:20)
    at Conf.<anonymous> (/usr/lib/node_modules/npm/lib/config/core.js:236:22)
    at /usr/lib/node_modules/npm/node_modules/uid-number/uid-number.js:39:14
    at ChildProcess.exithandler (child_process.js:282:5)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
/usr/lib/node_modules/npm/lib/utils/error-handler.js:205
  if (npm.config.get('json')) {
                 ^

TypeError: Cannot read property 'get' of undefined
    at process.errorHandler (/usr/lib/node_modules/npm/lib/utils/error-handler.js:205:18)
    at emitOne (events.js:116:13)
    at process.emit (events.js:211:7)
    at process._fatalException (bootstrap_node.js:378:26)
```