### PR TITLE
Update default ipfs-js lib version, pre-install all required npm packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,9 +102,35 @@ RUN mkdir $HOME/bin && \
     bn.js@4.11.8 \
     secp256k1@3.4.0 \
     debug@3.1.0 \
-    ipfs-api@22.2.4 \
+    ipfs-api@26.1.2 \
     dat@13.10.0 \
     && ln -s $HOME/node_modules/dat/bin/cli.js $HOME/bin/dat ;
+
+RUN cd $HOME; \
+    npm install -S react@16.6.1 \
+    @types/react@16.7.3 \
+    crypto-js@3.1.9-1 \
+    ethereumjs-tx@1.3.7 \
+    ipfs-api@26.1.2 \
+    jquery@3.3.1 \
+    js-sha256@0.9.0 \
+    react-bootstrap@0.32.4 \
+    react-dom@16.6.1 \
+    url-parse@1.4.4 \
+    web3@1.0.0-beta.36 \
+    && npm install -S @types/react-dom@16.0.9 \
+    babel-core@6.26.3 \
+    babel-loader@7.1.5 \
+    babel-preset-env@1.7.0 \
+    babel-preset-react@6.24.1 \
+    css-loader@1.0.1 \
+    file-loader@1.1.11 \
+    html-loader@0.5.5 \
+    html-webpack-plugin@3.2.0 \
+    style-loader@0.21.0 \
+    webpack@4.25.1 \
+    webpack-cli@3.1.2 \
+    webpack-dev-server@3.1.10 
 
 COPY ./bin/*.sh $HOME/bin/
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -72,7 +72,7 @@ RUN mkdir $HOME/bin && \
     bn.js@4.11.8 \
     secp256k1@3.4.0 \
     debug@3.1.0 \
-    ipfs-api@22.2.4 \
+    ipfs-api@26.1.2 \
     dat@13.10.0 \
     && ln -s $HOME/node_modules/dat/bin/cli.js $HOME/bin/dat
 


### PR DESCRIPTION
npm dependencies does not install all peer dependencies. We will manually install it for now.