### PR TITLE
Make 'master' branch default for all runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ v8.14.0
 ```
 
 The following branches are locked for several purposes. This current `master` branch is the development branch
-and the current stable one is `encryption-v0.3`. All development should be based on `encryption-v0.3` for now.
-* encryption-v0.1
-* encryption-v0.2
-* encryption-v0.3
+and the current stable one is `encryption-v0.3`. All development should be based on `master` and refer to
+`encryption-v0.3` for now.
+
+* `master` - new for development including new features, etc.
+* `encryption-v0.3` - stable, and backport features and PR from master if necessary
+* `encryption-v0.2` - old, stable, only for old version and compatibility test.
+* `encryption-v0.1` - old, don't use, just for reference.
 
 # How to Build and Run
 

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ if [ "$DEBUG" != "true" ] ; then
   build_cmd="docker build --no-cache"
 fi
 
-BUILD_BRANCH=${BUILD_BRANCH:-"encryption-v0.2"}
+BUILD_BRANCH=${BUILD_BRANCH:-"master"}
 
 # Build base blcksync/alpine-node:latest image
 $build_cmd \

--- a/run-prod.sh
+++ b/run-prod.sh
@@ -2,7 +2,7 @@
 
 CURR_DIR=$(cd $(dirname $0); pwd)
 
-BUILD_BRANCH=${BUILD_BRANCH:-"encryption-v0.2"}
+BUILD_BRANCH=${BUILD_BRANCH:-"master"}
 
 IPFS_DIR="$CURR_DIR/data"
 mkdir -p $IPFS_DIR

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BUILD_BRANCH=${BUILD_BRANCH:-"encryption-v0.2"}
+BUILD_BRANCH=${BUILD_BRANCH:-"master"}
 
 docker run --rm -it \
   --publish 127.0.0.1:3000:3000 \


### PR DESCRIPTION
Instead of using `encryption-v0.x`, we will now use `master` as default all the time. Manual switch to different branch at runtime is necessary if you want to run a different branch. e.g.

```
BUILD_BRANCH=encryption-v0.3 ./build.sh
```

```
BUILD_BRANCH=encryption-v0.3 ./run-prod.sh
```

otherwise, default will be `BUILD_BRANCH=master` and the docker image name will be `bc-ipfs-master`