### PR TITLE
Update dev hostname to use xxx-dev.blcksync.info and remove subdomain xxx.dev.blcksync.info. dev.blcksync.info will still be the portal entrance though

### DIFF
--- a/bc-ipfs/config/default.json
+++ b/bc-ipfs/config/default.json
@@ -1,7 +1,7 @@
 {
   "ipfs": {
     "api": {
-      "host": "ipfs-api.dev.blcksync.info",
+      "host": "ipfs-api-dev.blcksync.info",
       "port": "443",
       "protocol": "https"
     },
@@ -17,7 +17,7 @@
   },
   "es": {
     "search_url": {
-        "blockmed_ipfs": "http://es.dev.blcksync.info/blockmed-ipfs/_search/template"
+        "blockmed_ipfs": "http://es-dev.blcksync.info/blockmed-ipfs/_search/template"
     },
     "authorization": "Basic cmVhZGFsbDpyZWFkYWxs"
   },


### PR DESCRIPTION
`dev.blcksync.info` -> portal entrance 
`ipfs-api.dev.blcksync.info` -> `ipfs-api-dev.blcksync.info`
`es.dev.blcksync.info` -> `es-dev.blcksync.info`