### PR TITLE
Add bootstrap, react-router dependency to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,18 +55,23 @@ RUN mkdir $HOME/bin && \
     && ln -s $HOME/node_modules/dat/bin/cli.js $HOME/bin/dat ; \
     cd $HOME; git clone --depth 1 -b $BUILD_BRANCH https://github.com/blcksync/bc-ipfs.git; \
     cd bc-ipfs/bc-ipfs; npm install; \
-    npm install -S react@16.6.1 \
+    npm install -S react@16.6.3 \
     @types/react@16.7.3 \
+    react-router-dom@4.3.1 \
     crypto-js@3.1.9-1 \
     ethereumjs-tx@1.3.7 \
     ipfs-api@26.1.2 \
     jquery@3.3.1 \
     js-sha256@0.9.0 \
     react-bootstrap@0.32.4 \
-    react-dom@16.6.1 \
+    react-dom@16.6.3 \
+    react-confirm-alert@2.0.7 \
     url-parse@1.4.4 \
     web3@1.0.0-beta.36 \
     whatwg-fetch@3.0.0 \
+    config-webpack@1.0.4 \
+    bignumber.js@8.0.1 \
+    bootstrap@3.3.7 \
     && npm install -S @types/react-dom@16.0.9 \
     babel-core@6.26.3 \
     babel-loader@7.1.5 \

--- a/README.md
+++ b/README.md
@@ -213,20 +213,23 @@ to capture all required npm modules. Please report any other missing ones if you
 
 **Required**
 ```
-npm install -S react@16.6.1 \
+npm install -S react@16.6.3 \
   @types/react@16.7.3 \
+  react-router-dom@4.3.1 \
   crypto-js@3.1.9-1 \
   ethereumjs-tx@1.3.7 \
   ipfs-api@26.1.2 \
   jquery@3.3.1 \
   js-sha256@0.9.0 \
   react-bootstrap@0.32.4 \
-  react-dom@16.6.1 \
+  react-dom@16.6.3 \
   react-confirm-alert@2.0.7 \
   url-parse@1.4.4 \
   web3@1.0.0-beta.36 \
   whatwg-fetch@3.0.0 \
-  config-webpack
+  config-webpack@1.0.4 \
+  bignumber.js@8.0.1 \
+  bootstrap@3.3.7
 ```
 
 **Development Only**


### PR DESCRIPTION
Because `npm install` can't guarantee resolving dependency, we explicitly define all packages we need and document them.