### PR TITLE
Use event.persist for async events. 

### DIFF
--- a/bc-ipfs/src/components/FileListItem.js
+++ b/bc-ipfs/src/components/FileListItem.js
@@ -86,7 +86,7 @@ class FileListItem extends Component {
     let a_ipfsmeta = this.props.hashId;
     let a_encrypted_hash = '';
     console.log('Accessing with metadata = ' + a_ipfsmeta + ' and encryptedTxt = ' + a_encrypted_hash);
-    event.preventDefault();
+    event.persist();
 
     const contract_address = lib_reward_contract.options.address;
     console.log('Identified contract address = ' + contract_address);


### PR DESCRIPTION
Reference: https://reactjs.org/docs/events.html#event-pooling

When accessing the file, we see the following error msg. I'm wonder if this is related to what @HenryFanDi  is seeing on iOS, not getting the events, etc.
```
Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're accessing the method `preventDefault` on a released/nullified synthetic event. This is a no-op function. If you must keep the original synthetic event around, use event.persist(). See https://fb.me/react-event-pooling for more information.
```