### PR TITLE
Issue 35 access btn hanging on outofgas

### DIFF
--- a/bc-ipfs/src/components/FileListItem.js
+++ b/bc-ipfs/src/components/FileListItem.js
@@ -140,6 +140,20 @@ class FileListItem extends Component {
                 }
               },
             )
+            .catch(err => {
+              this.setState({ ['btn_access_state']: 'normal' });
+              console.error('err = ' + err);
+              confirmAlert({
+                title: 'Error',
+                message: `Either you ran out of gas or your wallet does not have sufficient BMD tokens`,
+                buttons: [
+                  {
+                    label: 'Got it!',
+                    onClick: () => {},
+                  },
+                ],
+              });
+            })
             .then(() => {
               let realKey = '';
               let decryptIPFSHash = '';


### PR DESCRIPTION
- Updated the error handling on un-caught errors.
- Display error dialog when error encounters instead of silently move on
- Replace `fetchKeyForIPFS` 換掉成 `fetchParallelKeyForIPFS(ipfsMetadata)` to avoid race condition and override on the same wallet address
- Added new state for `btn_access_state`, now we have 4 states to track `normal, accessing ,accessed, error`
- Added gate logic to stop other promise from executing and fetching data when the 1st one `decryptIPFS` fails.